### PR TITLE
Sprint Plan 2026-05-11

### DIFF
--- a/sprint.json
+++ b/sprint.json
@@ -1,8 +1,8 @@
 {
-  "sprint_active": true,
-  "sprint_start": "2026-05-03",
+  "sprint_active": false,
+  "sprint_start": "2026-05-11",
   "issues": [
-    {"number": 30, "title": "Add automated tests for data parsing and worker routing"},
-    {"number": 37, "title": "Security: fix staging cookie token and add CSP header"}
+    {"number": 54, "title": "Replace Gmail with Slack notifications for all agents"},
+    {"number": 9, "title": "Shareable status link — plain text summary for group chats"}
   ]
 }


### PR DESCRIPTION
## Retro

⚠️ **Staging/main drift:** `sprint/2026-05-03` (PR #55 — Tests + Security) has been open for 8 days without merging. The build is done and Cloudflare preview deployed successfully. Recommend merging PR #55 before or alongside this sprint to close the drift.

No open automated issues. No other stale branches.

## Backlog Health

Healthy. Eight+ S-effort issues remain (#54, #48, #9, #10, #3, #6, #5, #7). S tier not exhausted. Only two L-effort issues (#8, #12, #17) and all are well-specified. No vague issues to flag.

## This Sprint

### Issue #54 — Replace Gmail with Slack notifications for all agents (Effort: S)
- **Changes:** Update Usain, Kipchoge, Switzer, and Prefontaine agent configs/prompts to post via Slack incoming webhook instead of Gmail. Messages include rich formatting with links to PRs, staging URL, and dev bar.
- **Complexity:** S
- **Why:** Gmail MCP has been unreliable (auth dropped in two prior cycles). The Slack webhook is already wired and working today. Moving all agent notifications to Slack closes the communication gap with zero infrastructure cost and makes every sprint cycle more reliable.

### Issue #9 — Shareable status link — plain text summary for group chats (Effort: S)
- **Changes:** New Cloudflare Worker endpoint (`/status`) that fetches existing 511 + NWS + WFIGS feeds and returns a plain-text status summary (e.g. `🟢 All clear · Hwy 1 open · No fires · 10:45 AM`). No new data sources — reuses the feeds already powering the app.
- **Complexity:** S
- **Why:** West Marin residents share status in neighborhood Signal/WhatsApp groups. A copyable plain-text link closes the last-mile gap between the app and group chats. Pure S-effort — one new Worker route, no new dependencies.

## Issues Not Selected

- **#30, #37** — Already built in PR #55 (pending merge), not re-planned
- **#42** — Blocked (no confirmed live evac zones data source)
- **#5, #6, #7, #18, #19** — `data-source` label but no `Data source:` verification URL in issue body; unverifiable per CLAUDE.md policy
- **#12** — Critical label but L-effort; deferred
- **#49** — Has `wontfix` label; skipped

---

To approve: merge this PR. Build runs next.

_Generated by [Claude Code](https://claude.ai/code/session_01U6jJAPcxfHC5QpipDJaQc3)_