### PR TITLE
Sprint 2026-05-25 — Shareable status link

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -28,9 +28,10 @@ App also fetches directly from:
     └── ArcGIS / NIFC    (WFIGS active fire data)
 ```
 
-The Cloudflare Worker does two things:
+The Cloudflare Worker does three things:
 1. Serves the static app files
 2. Acts as a proxy for the 511 API (because 511 doesn't allow browser requests — the Worker fetches it server-side and passes it back)
+3. Serves `GET /status` — a plain-text one-liner (e.g. `🟢 All clear · Hwy 1 open · No fires · 10:45 AM PDT`) for pasting into neighborhood Signal/WhatsApp groups
 
 ---
 
@@ -380,6 +381,7 @@ GitHub issue #60 comment (agents read on next run)
 
 | Endpoint | Auth | What it does |
 |---|---|---|
+| `GET /status` | None (public) | Plain-text status summary for sharing in group chats |
 | `POST /notify` | `NOTIFY_SECRET` body field | Slack notification proxy (for non-CCR callers) |
 | `POST /slack-reply` | Slack signing secret (`SLACK_SIGNING_SECRET`) | Receives Slack thread replies, posts to issue #60 |
 

--- a/sprint-panel.json
+++ b/sprint-panel.json
@@ -1,29 +1,20 @@
 {
-  "built": false,
-  "sprint_start": "2026-05-11",
-  "retro": "Staging drift — sprint/2026-05-03 (PR #55) has been open 12+ days without merging.",
-  "backlog_health": "Healthy — 8+ S-effort issues remain. No vague L-effort issues.",
+  "built": true,
+  "sprint_start": "2026-05-25",
+  "retro": "Plan PR #56 (2026-05-11) merged 2026-05-23. Issue #54 (Replace Gmail with Slack) was deleted from the repo — skipped. No open automated issues. No stale sprint branches. Retro clean.",
+  "backlog_health": "Healthy. S-effort issues remain (#3, #6, #10, #48). L-effort issues #8, #12, #17 are well-specified. No vague issues.",
   "issues": [
-    {
-      "number": 54,
-      "title": "Replace Gmail with Slack notifications for all agents",
-      "effort": "S",
-      "meta": "Route Usain, Kipchoge, Switzer, Prefontaine notifications to #gh-wmc via GitHub Actions",
-      "body": "CCR agents post to a dedicated GitHub issue (#60). A GitHub Action triggers on each comment and forwards it to Slack via webhook. Eliminates Gmail MCP dependency.",
-      "preview_state": "calm",
-      "preview_target": ""
-    },
     {
       "number": 9,
       "title": "Shareable status link — plain text summary for group chats",
       "effort": "S",
-      "meta": "New /status endpoint returning plain-text summary for Signal/WhatsApp sharing",
-      "body": "New Cloudflare Worker route /status that fetches existing 511 + NWS + WFIGS feeds and returns a plain-text status summary. No new data sources.",
+      "meta": "New /status endpoint in worker.js",
+      "body": "GET /status returns a plain-text one-liner — e.g. \"🟢 All clear · Hwy 1 open · No fires · 10:45 AM PDT\" — by fetching NWS, 511, and WFIGS server-side. Paste it directly into a Signal or WhatsApp neighborhood group chat.",
       "preview_state": "calm",
-      "preview_target": ""
+      "preview_target": ".feed-footer"
     }
   ],
-  "blocker": "",
-  "pr_url": "https://github.com/john9josi/west-marin-civic/pull/56",
+  "blocker": "CLOUDFLARE_API_TOKEN unavailable in CCR — staging deploy must be run manually: npx wrangler deploy --env dev",
+  "pr_url": "https://github.com/john9josi/west-marin-civic/pull/63",
   "staging_url": "https://west-marin-civic-dev.john-b98.workers.dev"
 }

--- a/sprint.json
+++ b/sprint.json
@@ -1,8 +1,7 @@
 {
-  "sprint_active": false,
-  "sprint_start": "2026-05-11",
+  "sprint_active": true,
+  "sprint_start": "2026-05-25",
   "issues": [
-    {"number": 54, "title": "Replace Gmail with Slack notifications for all agents"},
     {"number": 9, "title": "Shareable status link — plain text summary for group chats"}
   ]
 }

--- a/worker.js
+++ b/worker.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import { parse511Roads } from './src/lib.js';
+
 const CORS = {
   'Access-Control-Allow-Origin':  '*',
   'Access-Control-Allow-Methods': 'GET, OPTIONS',
@@ -203,6 +205,114 @@ export default {
       }
 
       return new Response('ok', { status: 200 });
+    }
+
+    // Shareable plain-text status: GET /status
+    // Returns a one-liner suitable for pasting into Signal/WhatsApp group chats.
+    if (url.pathname === '/status' && request.method === 'GET') {
+      const timeStr = new Date().toLocaleTimeString('en-US', {
+        hour: 'numeric', minute: '2-digit', timeZone: 'America/Los_Angeles', timeZoneName: 'short',
+      });
+
+      try {
+        const FIRE_ALERT_EVENTS = ['Red Flag Warning', 'Fire Warning', 'Extreme Fire Danger'];
+        const FIRE_WATCH_EVENTS = ['Fire Weather Watch'];
+
+        const [rNWS, r511, rWFIGS] = await Promise.allSettled([
+          fetch('https://api.weather.gov/alerts/active?zone=CAZ505', {
+            headers: { 'User-Agent': 'westmarincivic.org (john@equanimity.is)' },
+          }).then(r => r.ok ? r.json() : null),
+
+          env.KEY_511
+            ? fetch(`https://api.511.org/traffic/events?api_key=${env.KEY_511}&format=json`, {
+                headers: { 'Accept-Encoding': 'identity' },
+              }).then(r => r.ok ? r.json() : null)
+            : Promise.resolve(null),
+
+          fetch(
+            'https://services3.arcgis.com/T4QMspbfLg3qTGWY/arcgis/rest/services/' +
+            'WFIGS_Interagency_Incident_Points_Current/FeatureServer/0/query' +
+            '?where=1%3D1&outFields=IncidentName%2CAcres%2CPercentContained%2CModifiedOnDateTime_dt' +
+            '&geometry=-123.1%2C37.75%2C-122.5%2C38.4&geometryType=esriGeometryEnvelope' +
+            '&inSR=4326&spatialRel=esriSpatialRelIntersects&returnGeometry=false&f=json'
+          ).then(r => r.ok ? r.json() : null),
+        ]);
+
+        // NWS: determine alert level
+        let nwsLevel = 'calm';
+        let nwsEvent = null;
+        if (rNWS.status === 'fulfilled' && rNWS.value) {
+          const features = rNWS.value.features || [];
+          for (const f of features) {
+            if (FIRE_ALERT_EVENTS.includes(f.properties?.event)) {
+              nwsLevel = 'alert';
+              nwsEvent = f.properties.event;
+              break;
+            }
+          }
+          if (nwsLevel === 'calm') {
+            for (const f of features) {
+              if (FIRE_WATCH_EVENTS.includes(f.properties?.event)) {
+                nwsLevel = 'watch';
+                nwsEvent = f.properties.event;
+                break;
+              }
+            }
+          }
+        }
+
+        // WFIGS: any active fire in West Marin bbox
+        let fire = null;
+        if (rWFIGS.status === 'fulfilled' && rWFIGS.value) {
+          const features = (rWFIGS.value.features || []).filter(f => f.attributes);
+          if (features.length) {
+            features.sort((a, b) =>
+              (b.attributes.ModifiedOnDateTime_dt || 0) - (a.attributes.ModifiedOnDateTime_dt || 0)
+            );
+            const a = features[0].attributes;
+            fire = {
+              name:  a.IncidentName || 'Active fire',
+              acres: a.Acres != null ? Math.round(a.Acres) : '?',
+            };
+          }
+        }
+
+        // 511: summarise Hwy 1 and other road closures
+        let roadStatus = 'Hwy 1 open';
+        if (r511.status === 'fulfilled' && r511.value) {
+          const roads = parse511Roads(r511.value);
+          const hwy1Closed  = roads['hwy1n']?.cls === 'r' || roads['hwy1s']?.cls === 'r';
+          const hwy1Caution = roads['hwy1n']?.cls === 'a' || roads['hwy1s']?.cls === 'a';
+          const otherClosed = Object.entries(roads).some(
+            ([id, r]) => id !== 'hwy1n' && id !== 'hwy1s' && r.cls === 'r'
+          );
+          if (hwy1Closed)        roadStatus = 'Hwy 1 closed';
+          else if (hwy1Caution)  roadStatus = 'Hwy 1: caution';
+          else if (otherClosed)  roadStatus = 'Road closure reported';
+        }
+
+        // Build response line
+        const level  = fire ? 'alert' : nwsLevel;
+        const emoji  = level === 'alert' ? '🔴' : level === 'watch' ? '🟡' : '🟢';
+        const status = fire
+          ? `Active fire — ${fire.name} · ${fire.acres} ac`
+          : level === 'alert' ? (nwsEvent || 'Active alert')
+          : level === 'watch' ? (nwsEvent || 'Fire Weather Watch')
+          : 'All clear';
+
+        const parts = [`${emoji} ${status}`, roadStatus];
+        if (!fire) parts.push('No fires');
+        parts.push(timeStr);
+
+        return new Response(parts.join(' · ') + '\nwestmarincivic.org', {
+          headers: { 'Content-Type': 'text/plain; charset=utf-8', 'Cache-Control': 'no-store' },
+        });
+      } catch {
+        return new Response(
+          `🟠 Status unknown · call 911 for emergencies · ${timeStr}\nwestmarincivic.org`,
+          { headers: { 'Content-Type': 'text/plain; charset=utf-8', 'Cache-Control': 'no-store' } }
+        );
+      }
     }
 
     // Dev environment: gate all requests behind a password + cookie session


### PR DESCRIPTION
## What was built

### Issue #9 — Shareable status link — plain text summary for group chats (Effort: S)

**`worker.js`**
- New `GET /status` endpoint — fetches NWS alerts, 511 road events, and WFIGS fires server-side and returns a single plain-text line, e.g.:
  - `🟢 All clear · Hwy 1 open · No fires · 10:45 AM PDT`
  - `🔴 Active fire — Tomales Ridge · 120 ac · Hwy 1 closed · 10:45 AM PDT`
  - `🟡 Fire Weather Watch · Hwy 1 open · No fires · 10:45 AM PDT`
- Endpoint is before the auth gate — accessible on both staging and prod without a password
- No new data sources — reuses the same NWS / 511 / WFIGS feeds already powering the app
- Imports `parse511Roads` from `src/lib.js` to share the road-matching logic
- Returns `Content-Type: text/plain; charset=utf-8`, `Cache-Control: no-store`
- Error fallback: `🟠 Status unknown · call 911 for emergencies · <time>`

**Not built this sprint:**
- Issue #54 (Replace Gmail with Slack notifications) was deleted from the repository and could not be built.

---

## Deploy blocker

`CLOUDFLARE_API_TOKEN` is not available in the CCR build environment — `npx wrangler deploy --env dev` could not be run automatically. To deploy:

```bash
npx wrangler deploy --env dev  # staging — verify /status returns plain text
npx wrangler deploy            # prod after staging review
```

## To ship
Merge this PR into `main`, then run the deploy commands above.

https://claude.ai/code/session_01SXpweafEhwZyAPMCvcxr9L

---
_Generated by [Claude Code](https://claude.ai/code/session_01SXpweafEhwZyAPMCvcxr9L)_