### PR TITLE
Sprint Plan 2026-06-01

### DIFF
--- a/sprint.json
+++ b/sprint.json
@@ -1,8 +1,8 @@
 {
   "sprint_active": false,
-  "sprint_start": "2026-05-11",
+  "sprint_start": "2026-06-01",
   "issues": [
-    {"number": 54, "title": "Replace Gmail with Slack notifications for all agents"},
-    {"number": 9, "title": "Shareable status link — plain text summary for group chats"}
+    {"number": 64, "title": "Add fetch timeouts to /status endpoint (AbortController)"},
+    {"number": 3, "title": "PWA install prompt — nudge first-time visitors to add to home screen"}
   ]
 }


### PR DESCRIPTION
## Retro

⚠️ **Staging/main drift:** `sprint/2026-05-25` (PR #63 — Shareable `/status` endpoint) has been open for 7 days without merging. Feature is built and deployed to staging. Retro issue opened: #67. Recommend merging PR #63 before or alongside this sprint.

No open automated issues.

## Backlog Health

Healthy. S-effort issues available: #64, #48, #3, #10. S tier not exhausted. Three L-effort issues (#8, #12, #17) but all are well-specified. No vague issues to flag.

## This Sprint

### Issue #64 — Add fetch timeouts to /status endpoint (AbortController) (Effort: S)
- **Changes:** `worker.js` — wrap the three parallel `fetch()` calls in `/status` (NWS, 511, WFIGS) each with an `AbortController` and a ~5s timeout, so the graceful `🟠 Status unknown` fallback fires within a bounded time even if all upstreams hang.
- **Complexity:** S
- **Why:** Kipchoge flagged this in the PR #63 review. The `/status` endpoint makes three parallel fetches with no timeout guard — if all three upstreams hang, the Worker stalls for up to 30s before returning an error. This is a single-function S-effort fix that closes a reliability gap in the feature just shipped.

### Issue #3 — PWA install prompt — nudge first-time visitors to add to home screen (Effort: S)
- **Changes:** `index.html` — listen for `beforeinstallprompt`, store the event, and show a small dismissible banner after 30s on first visit (localStorage gate). On iOS, detect `navigator.standalone` to show a manual "Add to Home Screen" tip instead.
- **Complexity:** S
- **Why:** Most West Marin residents won't discover the install option on their own. This is the single highest-leverage UX improvement still in the backlog — converts passive web visitors into installed PWA users who get the full offline experience. Has been in the backlog since launch.

## Issues Not Selected

- **#9** — Already built in open PR #63 (pending merge); not re-planned
- **#42** — Blocked (no confirmed live evac zone data source)
- **#49** — `wontfix` label; skipped
- **#5, #6, #7, #18, #19** — `data-source` label but endpoint verification deferred to sprint where selected; scored lower on impact/effort than picks above
- **#8, #12, #17** — L-effort; deferred
- **#48** — S-effort but lower impact than #64 (reliability) and #3 (community reach)

---

To approve: merge this PR. Build runs next.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SFfeQvJb9F7ppbB382t7Qh)_